### PR TITLE
Reconciliation for install of Application Monitoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -289,6 +289,14 @@
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
   digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
@@ -619,6 +627,7 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
+    "util/workqueue",
   ]
   pruneopts = "NT"
   revision = "1f13a808da65775f22cbf47862c4e5898d8f4ca1"
@@ -704,14 +713,24 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/controller",
+    "pkg/controller/controllerutil",
+    "pkg/event",
+    "pkg/handler",
+    "pkg/internal/controller",
     "pkg/internal/recorder",
     "pkg/leaderelection",
     "pkg/manager",
     "pkg/patch",
+    "pkg/predicate",
+    "pkg/reconcile",
     "pkg/recorder",
     "pkg/runtime/inject",
     "pkg/runtime/log",
+    "pkg/runtime/scheme",
     "pkg/runtime/signals",
+    "pkg/source",
+    "pkg/source/internal",
     "pkg/webhook/admission",
     "pkg/webhook/admission/types",
     "pkg/webhook/types",
@@ -724,11 +743,18 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/ghodss/yaml",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/ready",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/pkg/errors",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
@@ -738,10 +764,17 @@
     "k8s.io/code-generator/cmd/lister-gen",
     "k8s.io/code-generator/cmd/openapi-gen",
     "k8s.io/gengo/args",
+    "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/controller",
+    "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
+    "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/reconcile",
     "sigs.k8s.io/controller-runtime/pkg/runtime/log",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/scheme",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
+    "sigs.k8s.io/controller-runtime/pkg/source",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-ORG=integreatly
-NAMESPACE=application-monitoring
-PROJECT=application-monitoring-operator
+ORG ?= integreatly
+NAMESPACE ?= middleware-monitoring
+PROJECT ?= application-monitoring-operator
 REG=quay.io
 SHELL=/bin/bash
-TAG=0.0.1
+TAG ?= 0.0.1
 PKG=github.com/integr8ly/application-monitoring-operator
 TEST_DIRS?=$(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go -exec dirname {} \\; | sort | uniq")
 TEST_POD_NAME=application-monitoring-operator-test

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,4 +4,5 @@ RUN apk upgrade --update --no-cache
 
 USER nobody
 
+ADD templates/*.yaml /usr/local/bin/templates/
 ADD build/_output/bin/application-monitoring-operator /usr/local/bin/application-monitoring-operator

--- a/deploy/roles/alertmanager-clusterrole.yaml
+++ b/deploy/roles/alertmanager-clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: alertmanager-application-monitoring
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  attributeRestrictions: null
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  attributeRestrictions: null
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/deploy/roles/alertmanager-clusterrole_binding.yaml
+++ b/deploy/roles/alertmanager-clusterrole_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: authorization.openshift.io/v1
+groupNames: null
+kind: ClusterRoleBinding
+metadata:
+  name: alertmanager-application-monitoring
+roleRef:
+  name: alertmanager-application-monitoring
+subjects:
+- kind: ServiceAccount
+  name: alertmanager
+  namespace: middleware-monitoring
+userNames:
+- system:serviceaccount:middleware-monitoring:alertmanager

--- a/deploy/roles/alertmanager-clusterrole_binding.yaml
+++ b/deploy/roles/alertmanager-clusterrole_binding.yaml
@@ -8,6 +8,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: alertmanager
-  namespace: middleware-monitoring
+  namespace: {{ .Namespace }}
 userNames:
-- system:serviceaccount:middleware-monitoring:alertmanager
+- system:serviceaccount:{{ .Namespace }}:alertmanager

--- a/deploy/roles/grafana-operator-clusterrole.yaml
+++ b/deploy/roles/grafana-operator-clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-operator
+rules:
+  - apiGroups:
+      - ""
+    attributeRestrictions: null
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - integreatly.org
+    attributeRestrictions: null
+    resources:
+      - grafanadashboards
+      - grafanas
+    verbs:
+      - '*'

--- a/deploy/roles/grafana-operator-clusterrole_binding.yaml
+++ b/deploy/roles/grafana-operator-clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-operator
+roleRef:
+  name: grafana-operator
+subjects:
+  - kind: ServiceAccount
+    name: grafana-operator
+    namespace: middleware-monitoring
+userNames:
+  - system:serviceaccount:middleware-monitoring:grafana-operator

--- a/deploy/roles/grafana-operator-clusterrole_binding.yaml
+++ b/deploy/roles/grafana-operator-clusterrole_binding.yaml
@@ -7,6 +7,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: grafana-operator
-    namespace: middleware-monitoring
+    namespace: {{ .Namespace }}
 userNames:
-  - system:serviceaccount:middleware-monitoring:grafana-operator
+  - system:serviceaccount:{{ .Namespace }}:grafana-operator

--- a/deploy/roles/prometheus-clusterrole.yaml
+++ b/deploy/roles/prometheus-clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus-application-monitoring
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/deploy/roles/prometheus-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-clusterrole_binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-application-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-application-monitoring
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: middleware-monitoring
+userNames:
+- system:serviceaccount:middleware-monitoring:prometheus

--- a/deploy/roles/prometheus-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-clusterrole_binding.yaml
@@ -9,6 +9,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: middleware-monitoring
+  namespace: {{ .Namespace }}
 userNames:
-- system:serviceaccount:middleware-monitoring:prometheus
+- system:serviceaccount:{{ .Namespace }}:prometheus

--- a/deploy/roles/prometheus-operator-clusterrole.yaml
+++ b/deploy/roles/prometheus-operator-clusterrole.yaml
@@ -1,0 +1,66 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-application-monitoring-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - prometheuses/finalizers
+  - alertmanagers/finalizers
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/roles/prometheus-operator-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-operator-clusterrole_binding.yaml
@@ -9,6 +9,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: middleware-monitoring
+  namespace: {{ .Namespace }}
 userNames:
-- system:serviceaccount:middleware-monitoring:prometheus-operator
+- system:serviceaccount:{{ .Namespace }}:prometheus-operator

--- a/deploy/roles/prometheus-operator-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-operator-clusterrole_binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-application-monitoring-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-application-monitoring-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: middleware-monitoring
+userNames:
+- system:serviceaccount:middleware-monitoring:prometheus-operator

--- a/pkg/apis/applicationmonitoring/v1alpha1/applicationmonitoring_types.go
+++ b/pkg/apis/applicationmonitoring/v1alpha1/applicationmonitoring_types.go
@@ -17,6 +17,7 @@ type ApplicationMonitoringSpec struct {
 type ApplicationMonitoringStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
+	Phase int `json:"phase"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/applicationmonitoring/resourceHelper.go
+++ b/pkg/controller/applicationmonitoring/resourceHelper.go
@@ -1,0 +1,36 @@
+package applicationmonitoring
+
+import (
+	"github.com/ghodss/yaml"
+	applicationmonitoring "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type ResourceHelper struct {
+	templateHelper *TemplateHelper
+	cr             *applicationmonitoring.ApplicationMonitoring
+}
+
+func newResourceHelper(cr *applicationmonitoring.ApplicationMonitoring) *ResourceHelper {
+	return &ResourceHelper{
+		templateHelper: newTemplateHelper(cr),
+		cr:             cr,
+	}
+}
+
+func (r *ResourceHelper) createResource(template string) (runtime.Object, error) {
+	tpl, err := r.templateHelper.loadTemplate(template)
+	if err != nil {
+		return nil, err
+	}
+
+	resource := unstructured.Unstructured{}
+	err = yaml.Unmarshal(tpl, &resource)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &resource, nil
+}

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -1,0 +1,84 @@
+package applicationmonitoring
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"text/template"
+
+	applicationmonitoring "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
+)
+
+const (
+	GrafanaCRName                        = "grafana-cr"
+	GrafanaOperatorDeploymentName        = "grafana-operator-deployment"
+	GrafanaOperatorRoleBindingName       = "grafana-operator-rolebinding"
+	GrafanaOperatorRoleName              = "grafana-operator-role"
+	GrafanaOperatorServiceAccountName    = "grafana-operator-serviceaccount"
+	AlertManagerCRName                   = "prometheus-alertmanager-cr"
+	AlertManagerSecretName               = "prometheus-alertmanager-secret"
+	AlertManagerServiceAccountName       = "prometheus-alertmanager-serviceaccount"
+	AlertManagerServiceName              = "prometheus-alertmanager-service"
+	PrometheusOperatorDeploymentName     = "prometheus-operator-deployment"
+	PrometheusOperatorServiceAccountName = "prometheus-operator-serviceaccount"
+	PrometheusCRName                     = "prometheus-prometheus-cr"
+	PrometheusRuleCRName                 = "prometheus-prometheusrule-cr"
+	PrometheusServiceAccountName         = "prometheus-serviceaccount"
+	PrometheusServiceName                = "prometheus-service"
+	ServiceMonitorGrafanaCRName          = "prometheus-servicemonitor-grafana-cr"
+	ServiceMonitorPrometheusCRName       = "prometheus-servicemonitor-prometheus-cr"
+)
+
+type Parameters struct {
+	PrometheusOperatorDeploymentName string
+	Namespace                        string
+}
+
+type TemplateHelper struct {
+	Parameters   Parameters
+	TemplatePath string
+}
+
+// Creates a new templates helper and populates the values for all
+// templates properties. Some of them (like the hostname) are set
+// by the user in the custom resource
+func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring) *TemplateHelper {
+	param := Parameters{
+		PrometheusOperatorDeploymentName: PrometheusOperatorDeploymentName,
+		Namespace:                        cr.Namespace,
+	}
+
+	templatePath := os.Getenv("TEMPLATE_PATH")
+	if templatePath == "" {
+		templatePath = "./templates"
+	}
+
+	return &TemplateHelper{
+		Parameters:   param,
+		TemplatePath: templatePath,
+	}
+}
+
+// load a templates from a given resource name. The templates must be located
+// under ./templates and the filename must be <resource-name>.yaml
+func (h *TemplateHelper) loadTemplate(name string) ([]byte, error) {
+	path := fmt.Sprintf("%s/%s.yaml", h.TemplatePath, name)
+	tpl, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, err := template.New("application-monitoring").Parse(string(tpl))
+	if err != nil {
+		return nil, err
+	}
+
+	var buffer bytes.Buffer
+	err = parsed.Execute(&buffer, h.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/templates/grafana-cr.yaml
+++ b/templates/grafana-cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: application-monitoring
+  namespace: {{ .Namespace }}
+spec:
+  prometheusUrl: "http://prometheus-application-monitoring:9090"

--- a/templates/grafana-operator-deployment.yaml
+++ b/templates/grafana-operator-deployment.yaml
@@ -33,6 +33,8 @@ spec:
             periodSeconds: 10
             failureThreshold: 1
           env:
+            - name: TEMPLATE_PATH
+              value: /usr/local/bin/templates
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/templates/grafana-operator-deployment.yaml
+++ b/templates/grafana-operator-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-operator
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: grafana-operator
+  template:
+    metadata:
+      labels:
+        name: grafana-operator
+    spec:
+      serviceAccountName: grafana-operator
+      containers:
+        - name: grafana-operator
+          # Replace this with the built image name
+          image: quay.io/integreatly/grafana-operator:0.0.1
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - grafana-operator
+          imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "grafana-operator"

--- a/templates/grafana-operator-role.yaml
+++ b/templates/grafana-operator-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: grafana-operator
+  namespace: {{ .Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - integreatly.org
+  resources:
+  - '*'
+  - grafanadashboards
+  verbs:
+  - '*'

--- a/templates/grafana-operator-rolebinding.yaml
+++ b/templates/grafana-operator-rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: grafana-operator
+  namespace: {{ .Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: grafana-operator
+roleRef:
+  kind: Role
+  name: grafana-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/templates/grafana-operator-serviceaccount.yaml
+++ b/templates/grafana-operator-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-operator
+  namespace: {{ .Namespace }}

--- a/templates/prometheus-alertmanager-cr.yaml
+++ b/templates/prometheus-alertmanager-cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: application-monitoring
+  namespace: {{ .Namespace }}
+spec:
+  listenLocal: false
+  serviceAccountName: alertmanager

--- a/templates/prometheus-alertmanager-secret.yaml
+++ b/templates/prometheus-alertmanager-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  alertmanager.yaml: >-
+    Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogNW0Kcm91dGU6CiAgZ3JvdXBfd2FpdDogMzBzCiAgZ3JvdXBfaW50ZXJ2YWw6IDVtCiAgcmVwZWF0X2ludGVydmFsOiAxMmgKICByZWNlaXZlcjogZGVmYXVsdAogIHJvdXRlczoKICAtIG1hdGNoOgogICAgICBhbGVydG5hbWU6IERlYWRNYW5zU3dpdGNoCiAgICByZXBlYXRfaW50ZXJ2YWw6IDVtCiAgICByZWNlaXZlcjogZGVhZG1hbnNzd2l0Y2gKcmVjZWl2ZXJzOgotIG5hbWU6IGRlZmF1bHQKLSBuYW1lOiBkZWFkbWFuc3N3aXRjaAo=
+kind: Secret
+metadata:
+  name: alertmanager-application-monitoring
+  namespace: {{ .Namespace }}
+type: Opaque

--- a/templates/prometheus-alertmanager-service.yaml
+++ b/templates/prometheus-alertmanager-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-application-monitoring
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+    - name: web
+      port: 6783
+      protocol: TCP
+      targetPort: web
+  selector:
+    alertmanager: application-monitoring
+    app: alertmanager
+  sessionAffinity: None
+  type: ClusterIP

--- a/templates/prometheus-alertmanager-serviceaccount.yaml
+++ b/templates/prometheus-alertmanager-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alertmanager
+  namespace: {{ .Namespace }}

--- a/templates/prometheus-operator-deployment.yaml
+++ b/templates/prometheus-operator-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: prometheus-operator
+  name: prometheus-operator
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: prometheus-operator
+  template:
+    metadata:
+      labels:
+        k8s-app: prometheus-operator
+    spec:
+      containers:
+      - args:
+        - --kubelet-service=kube-system/kubelet
+        - --logtostderr=true
+        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.26.0
+        - --namespaces=
+        image: quay.io/coreos/prometheus-operator:v0.26.0
+        name: prometheus-operator
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext: {}
+      serviceAccountName: prometheus-operator

--- a/templates/prometheus-operator-serviceaccount.yaml
+++ b/templates/prometheus-operator-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-operator
+  namespace: {{ .Namespace }}

--- a/templates/prometheus-prometheus-cr.yaml
+++ b/templates/prometheus-prometheus-cr.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: application-monitoring
+  namespace: {{ .Namespace }}
+  labels:
+    prometheus: application-monitoring
+spec:
+  alerting:
+    alertmanagers:
+      - name: alertmanager-application-monitoring
+        namespace: {{ .Namespace }}
+        port: web
+  resources:
+    requests:
+      memory: 400Mi
+  serviceAccountName: prometheus
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      monitoring-key: 'middleware'
+  serviceMonitorSelector:
+    matchLabels:
+      monitoring-key: 'middleware'
+  ruleSelector:
+    matchLabels:
+      monitoring-key: 'middleware'
+  ruleNamespaceSelector:
+    matchLabels:
+      monitoring-key: 'middleware'

--- a/templates/prometheus-prometheusrule-cr.yaml
+++ b/templates/prometheus-prometheusrule-cr.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: 'middleware'
+  name: prometheus
+  namespace: {{ .Namespace }}
+spec:
+  groups:
+    - name: general.rules
+      rules:
+        - alert: DeadMansSwitch
+          annotations:
+            description: >-
+              This is a DeadMansSwitch meant to ensure that the entire Alerting
+              pipeline is functional.
+            summary: Alerting DeadMansSwitch
+          expr: vector(1)
+          labels:
+            severity: none

--- a/templates/prometheus-service.yaml
+++ b/templates/prometheus-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-application-monitoring
+  namespace: {{ .Namespace }}
+  labels:
+    application-monitoring: 'true'
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30900
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    app: prometheus

--- a/templates/prometheus-serviceaccount.yaml
+++ b/templates/prometheus-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: {{ .Namespace }}

--- a/templates/prometheus-servicemonitor-grafana-cr.yaml
+++ b/templates/prometheus-servicemonitor-grafana-cr.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: 'middleware'
+  name: grafana
+  namespace: {{ .Namespace }}
+spec:
+  endpoints:
+    - port: grafana
+      scheme: http
+  selector:
+    matchLabels:
+      application-monitoring: 'true'

--- a/templates/prometheus-servicemonitor-prometheus-cr.yaml
+++ b/templates/prometheus-servicemonitor-prometheus-cr.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: 'middleware'
+  name: prometheus
+  namespace: {{ .Namespace }}
+spec:
+  endpoints:
+    - port: web
+  selector:
+    matchLabels:
+      application-monitoring: 'true'

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}


### PR DESCRIPTION
*Verify steps*

```
oc new-project middleware-monitoring
oc create -f ./deploy/roles/
oc create -f ./deploy/crds
make code/run
```

The middleware-monitoring namespace should eventually reconcile with below pods:

```
oc get po
NAME                                    READY     STATUS    RESTARTS   AGE
alertmanager-application-monitoring-0   2/2       Running   0          32m
grafana-operator-fb565d8cc-n7fwv        1/1       Running   7          28m
prometheus-application-monitoring-0     3/3       Running   1          17m
prometheus-operator-6c7b4fb6c4-xkwv7    1/1       Running   0          32m
```

*NOTE* There should also be a `grafana` pod, but there is an error in the grafana operator logs at present (see comment below for more info)


*TODO*

* [x] Add cluster roles & rolebindings required by dependent operators
* [x] Add crds for dependent operators
* [x] Install Grafana Operator & CR
* [x] Install Prometheus Operator & CRs
* (in a follow up PR) Configure Grafana, Alertmanager & Prometheus for monitoring other namepsaces