### PR TITLE
add prometheus service monitor

### DIFF
--- a/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
+++ b/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
@@ -183,7 +183,7 @@ func (r *ReconcileApplicationMonitoring) CreateAlertManagerCRs(cr *applicationmo
 func (r *ReconcileApplicationMonitoring) CreateAux(cr *applicationmonitoringv1alpha1.ApplicationMonitoring) (reconcile.Result, error) {
 	log.Info("Phase: Create auxiliary resources")
 
-	for _, resourceName := range []string{ServiceMonitorName, PrometheusRuleName} {
+	for _, resourceName := range []string{PrometheusServiceMonitorName, GrafanaServiceMonitorName, PrometheusRuleName} {
 		if err := r.CreateResource(cr, resourceName); err != nil {
 			log.Info(fmt.Sprintf("Error in CreateAux, resourceName=%s : err=%s", resourceName, err))
 			// Requeue so it can be attempted again

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -26,9 +26,10 @@ const (
 	AlertManagerCrName                   = "alertmanager"
 	AlertManagerServiceName              = "alertmanager-service"
 	AlertManagerSecretName               = "alertmanager-secret"
-	ServiceMonitorName                   = "servicemonitor"
+	PrometheusServiceMonitorName         = "prometheus-servicemonitor"
 	PrometheusRuleName                   = "prometheus-rule"
 	AlertManagerRouteName                = "alertmanager-route"
+	GrafanaServiceMonitorName            = "grafana-servicemonitor"
 )
 
 type Parameters struct {
@@ -47,6 +48,8 @@ type Parameters struct {
 	AlertManagerCrName                string
 	AlertManagerServiceName           string
 	AlertManagerRouteName             string
+	GrafanaServiceMonitorName         string
+	PrometheusServiceMonitorName      string
 }
 
 type TemplateHelper struct {
@@ -74,6 +77,8 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring) *Templat
 		AlertManagerCrName:                AlertManagerCrName,
 		AlertManagerServiceName:           AlertManagerServiceName,
 		AlertManagerRouteName:             AlertManagerRouteName,
+		GrafanaServiceMonitorName:         GrafanaServiceMonitorName,
+		PrometheusServiceMonitorName:      PrometheusServiceMonitorName,
 	}
 
 	templatePath := os.Getenv("TEMPLATE_PATH")

--- a/templates/grafana-servicemonitor.yaml
+++ b/templates/grafana-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: 'middleware'
+  name: {{ .GrafanaServiceMonitorName }}
+  namespace: {{ .Namespace }}
+spec:
+  endpoints:
+    - port: grafana
+      scheme: http
+  selector:
+    matchLabels:
+      application-monitoring: 'true'

--- a/templates/prometheus-rule.yaml
+++ b/templates/prometheus-rule.yaml
@@ -2,8 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    prometheus: {{ .ApplicationMonitoringName}}
-    role: alert-rules
+    monitoring-key: 'middleware'
   name: prometheus-application-monitoring-rules
   namespace: {{ .Namespace }}
 spec:

--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -2,13 +2,12 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    application-monitoring: 'true'
-  name: grafana
+    monitoring-key: 'middleware'
+  name: {{ .PrometheusServiceMonitorName }}
   namespace: {{ .Namespace }}
 spec:
   endpoints:
-    - port: grafana
-      scheme: http
+    - port: web
   selector:
     matchLabels:
       application-monitoring: 'true'

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -17,14 +17,13 @@ spec:
   serviceAccountName: prometheus-application-monitoring
   serviceMonitorNamespaceSelector:
     matchLabels:
-      application-monitoring: 'true'
+      monitoring-key: 'middleware'
   serviceMonitorSelector:
     matchLabels:
-      application-monitoring: 'true'
+      monitoring-key: 'middleware'
   ruleSelector:
     matchLabels:
-      prometheus: {{ .ApplicationMonitoringName }}
-      role: alert-rules
+      monitoring-key: 'middleware'
   ruleNamespaceSelector:
     matchLabels:
-      application-monitoring: 'true'
+      monitoring-key: 'middleware'


### PR DESCRIPTION
Adds a service monitor for prometheus and uses `monitoring-key: 'middleware'` instead of `application-monitoring: 'true'`