### PR TITLE
prevent operators from granting extra roles

### DIFF
--- a/deploy/operator_roles/role.yaml
+++ b/deploy/operator_roles/role.yaml
@@ -43,9 +43,17 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanadashboards
+      - grafanas
+    verbs:
+      - '*'
+  - apiGroups:
       - route.openshift.io
     resources:
       - routes
+      - routes/custom-host
     verbs:
       - '*'
   - apiGroups:
@@ -54,5 +62,11 @@ rules:
     resources:
       - rolebindings
       - roles
+    verbs:
+      - '*'
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
     verbs:
       - '*'


### PR DESCRIPTION
The monitoring operator role needs to have (at least) all permissions that the roles it creates (or indirectly creates) have. Thanks @aidenkeating for figuring this out!