### PR TITLE
fix grafana serviceaccount name

### DIFF
--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -33,23 +33,22 @@ const (
 )
 
 type Parameters struct {
-	ApplicationMonitoringName         string
-	PrometheusOperatorName            string
-	Namespace                         string
-	GrafanaOperatorName               string
-	GrafanaCrName                     string
-	GrafanaImage                      string
-	GrafanaOperatorServiceAccountName string
-	GrafanaOperatorRoleName           string
-	GrafanaOperatorRoleBindingName    string
-	PrometheusCrName                  string
-	PrometheusServiceName             string
-	AlertManagerServiceAccountName    string
-	AlertManagerCrName                string
-	AlertManagerServiceName           string
-	AlertManagerRouteName             string
-	GrafanaServiceMonitorName         string
-	PrometheusServiceMonitorName      string
+	ApplicationMonitoringName      string
+	PrometheusOperatorName         string
+	Namespace                      string
+	GrafanaOperatorName            string
+	GrafanaCrName                  string
+	GrafanaImage                   string
+	GrafanaOperatorRoleName        string
+	GrafanaOperatorRoleBindingName string
+	PrometheusCrName               string
+	PrometheusServiceName          string
+	AlertManagerServiceAccountName string
+	AlertManagerCrName             string
+	AlertManagerServiceName        string
+	AlertManagerRouteName          string
+	GrafanaServiceMonitorName      string
+	PrometheusServiceMonitorName   string
 }
 
 type TemplateHelper struct {
@@ -62,23 +61,22 @@ type TemplateHelper struct {
 // by the user in the custom resource
 func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring) *TemplateHelper {
 	param := Parameters{
-		Namespace:                         cr.Namespace,
-		GrafanaOperatorName:               GrafanaOperatorName,
-		GrafanaCrName:                     GrafanaCrName,
-		GrafanaOperatorServiceAccountName: GrafanaOperatorServiceAccountName,
-		GrafanaOperatorRoleBindingName:    GrafanaOperatorRoleBindingName,
-		GrafanaOperatorRoleName:           GrafanaOperatorRoleName,
-		GrafanaImage:                      "quay.io/integreatly/grafana-operator:0.0.1",
-		PrometheusOperatorName:            PrometheusOperatorName,
-		ApplicationMonitoringName:         ApplicationMonitoringName,
-		PrometheusCrName:                  PrometheusCrName,
-		PrometheusServiceName:             PrometheusServiceName,
-		AlertManagerServiceAccountName:    AlertManagerServiceAccountName,
-		AlertManagerCrName:                AlertManagerCrName,
-		AlertManagerServiceName:           AlertManagerServiceName,
-		AlertManagerRouteName:             AlertManagerRouteName,
-		GrafanaServiceMonitorName:         GrafanaServiceMonitorName,
-		PrometheusServiceMonitorName:      PrometheusServiceMonitorName,
+		Namespace:                      cr.Namespace,
+		GrafanaOperatorName:            GrafanaOperatorName,
+		GrafanaCrName:                  GrafanaCrName,
+		GrafanaOperatorRoleBindingName: GrafanaOperatorRoleBindingName,
+		GrafanaOperatorRoleName:        GrafanaOperatorRoleName,
+		GrafanaImage:                   "quay.io/integreatly/grafana-operator:0.0.1",
+		PrometheusOperatorName:         PrometheusOperatorName,
+		ApplicationMonitoringName:      ApplicationMonitoringName,
+		PrometheusCrName:               PrometheusCrName,
+		PrometheusServiceName:          PrometheusServiceName,
+		AlertManagerServiceAccountName: AlertManagerServiceAccountName,
+		AlertManagerCrName:             AlertManagerCrName,
+		AlertManagerServiceName:        AlertManagerServiceName,
+		AlertManagerRouteName:          AlertManagerRouteName,
+		GrafanaServiceMonitorName:      GrafanaServiceMonitorName,
+		PrometheusServiceMonitorName:   PrometheusServiceMonitorName,
 	}
 
 	templatePath := os.Getenv("TEMPLATE_PATH")

--- a/templates/grafana-operator-role-binding.yaml
+++ b/templates/grafana-operator-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .GrafanaOperatorServiceAccountName }}
+    name: grafana-serviceaccount
 roleRef:
   kind: Role
   name: {{ .GrafanaOperatorRoleName }}

--- a/templates/grafana-operator-role.yaml
+++ b/templates/grafana-operator-role.yaml
@@ -38,6 +38,7 @@ rules:
     resources:
       - grafanadashboards
       - grafanas
+      - grafanas/finalizers
     verbs:
       - '*'
   - apiGroups:

--- a/templates/grafana-operator-service-account.yaml
+++ b/templates/grafana-operator-service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .GrafanaOperatorServiceAccountName }}
+  name: grafana-serviceaccount
   namespace: {{ .Namespace }}

--- a/templates/grafana-operator.yaml
+++ b/templates/grafana-operator.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         name: {{ .GrafanaOperatorName }}
     spec:
-      serviceAccountName: {{ .GrafanaOperatorServiceAccountName }}
+      serviceAccountName: grafana-serviceaccount
       containers:
         - name: {{ .GrafanaOperatorName }}
           image: {{ .GrafanaImage }}


### PR DESCRIPTION
The name of the Grafana serviceaccount that the operator creates differed from the one in the ClusterRoleBinding. This PR aligns the operator name with the one in the installer.