### PR TITLE
need to add extra role to parent operator

### DIFF
--- a/deploy/operator_roles/role.yaml
+++ b/deploy/operator_roles/role.yaml
@@ -47,6 +47,7 @@ rules:
     resources:
       - grafanadashboards
       - grafanas
+      - grafanas/finalizers
     verbs:
       - '*'
   - apiGroups:


### PR DESCRIPTION
Prevent the grafana operator from trying to grant extra permissions by adding the extra permission to the parent operator.