### PR TITLE
Add install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ORG ?= integreatly
-NAMESPACE ?= middleware-monitoring
+NAMESPACE ?= application-monitoring
 PROJECT ?= application-monitoring-operator
 REG=quay.io
 SHELL=/bin/bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,38 @@ The following Grafana resources are supported:
 
 Triggers the installation of the monitoring stack when created. This is achieved by deploying two other operators that install Prometheus and Grafana respectively.
 
-# Running locally
+# Installation
+
+You will need cluster admin permissions to create CRDs, ClusterRoles & ClusterRoleBindings.
+ClusterRoles are needed to allow the operators to watch multiple namespaces.
+
+```
+oc new-project application-monitoring
+```
+
+Grafana CRDs
+
+```
+oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/Grafana.yaml
+oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/GrafanaDashboard.yaml
+```
+
+Cluster Roles & RoleBindings
+
+```
+oc apply -f ./deploy/roles
+```
+
+Application Monitoring Operator
+
+```
+oc apply -f ./deploy/operator_roles/
+oc apply -f ./deploy/crds/ApplicationMonitoring.yaml
+oc apply -f ./deploy/operator.yaml
+oc apply -f ./deploy/examples/ApplicationMonitoring.yaml
+```
+
+# Running locally (for development)
 
 You can run the Operator locally against a remote namespace. The name of the namespace should be `application-monitoring`. To run the operator execute:
 

--- a/deploy/roles/alertmanager-clusterrole_binding.yaml
+++ b/deploy/roles/alertmanager-clusterrole_binding.yaml
@@ -8,6 +8,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: alertmanager
-  namespace: middleware-monitoring
+  namespace: application-monitoring
 userNames:
 - system:serviceaccount:application-monitoring:alertmanager

--- a/deploy/roles/grafana-operator-clusterrole_binding.yaml
+++ b/deploy/roles/grafana-operator-clusterrole_binding.yaml
@@ -7,6 +7,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: grafana-serviceaccount
-    namespace: middleware-monitoring
+    namespace: application-monitoring
 userNames:
-  - system:serviceaccount:application-monitoring:grafana-operator
+  - system:serviceaccount:application-monitoring:grafana-serviceaccount

--- a/deploy/roles/prometheus-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-clusterrole_binding.yaml
@@ -9,6 +9,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: middleware-monitoring
+  namespace: application-monitoring
 userNames:
 - system:serviceaccount:application-monitoring:prometheus

--- a/deploy/roles/prometheus-operator-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-operator-clusterrole_binding.yaml
@@ -9,6 +9,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: middleware-monitoring
+  namespace: application-monitoring
 userNames:
 - system:serviceaccount:application-monitoring:prometheus-operator


### PR DESCRIPTION
* adds install instructions to the README (for installing in a vanilla openshift 3.11 cluster)
* updates some rolebindings to reference the correct namespace & serviceaccount

*Verify steps*

* follow install instructions
* verify everything is reconciled (have pods running similar to output below)

```
oc get po
NAME                                               READY     STATUS    RESTARTS   AGE
alertmanager-application-monitoring-0              2/2       Running   0          43m
application-monitoring-operator-759c888dd6-bptw2   1/1       Running   0          43m
grafana-deployment-79cf9f88c8-l47lk                1/1       Running   0          43m
grafana-operator-795567557-vk25k                   1/1       Running   0          43m
prometheus-application-monitoring-0                3/3       Running   1          43m
prometheus-operator-65cfb97489-r7cjp               1/1       Running   0          43m
```