### PR TITLE
the name of the prometheus service has changed

### DIFF
--- a/templates/grafana.yaml
+++ b/templates/grafana.yaml
@@ -4,4 +4,4 @@ metadata:
   name: {{ .GrafanaCrName }}
   namespace: {{ .Namespace }}
 spec:
-  prometheusUrl: "http://prometheus-application-monitoring:9090"
+  prometheusUrl: "http://prometheus-service:9090"


### PR DESCRIPTION
The name of the prometheus service created by this operator has change. This needs to be updated in the Grafana CR or otherwise Grafana won't be able to connect to Prometheus.