### PR TITLE
update alertmanager service name and hardcode namespaces for now

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   alerting:
     alertmanagers:
-      - name: alertmanager-application-monitoring
+      - name: {{ .AlertManagerServiceName }}
         namespace: {{ .Namespace }}
         port: web
   resources:


### PR DESCRIPTION
Two fixes:

1. The name of the alertmanager in the Prometheus resource must match the alertmanager service
1. Hardcode the middleware namespaces for now until we can verify the prometheus operator watching all namespaces