### PR TITLE
🐛 Use clusterIP instead of NodePort for prometheus

### DIFF
--- a/templates/prometheus-service.yaml
+++ b/templates/prometheus-service.yaml
@@ -6,12 +6,12 @@ metadata:
   labels:
     application-monitoring: "true"
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - name: web
-      nodePort: 30900
       port: 9090
       protocol: TCP
       targetPort: web
   selector:
     app: prometheus
+  sessionAffinity: None


### PR DESCRIPTION
Fixes this error

```
error creating resource: Service \"prometheus-service\" is invalid: spec.ports[0].nodePort: Invalid value: 30900: provided port is already allocated
```

The application monitornig prometheus instance doesn't require a
nodeport. It will be accessed via a route.