### PR TITLE
scan all namespaces for prometheus resources

### DIFF
--- a/templates/prometheus-operator.yaml
+++ b/templates/prometheus-operator.yaml
@@ -21,7 +21,7 @@ spec:
             - --logtostderr=true
             - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
             - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.26.0
-            - --namespaces={{ .Namespace }}
+            - --namespaces=
           image: quay.io/coreos/prometheus-operator:v0.26.0
           name: prometheus-application-operator
           ports:


### PR DESCRIPTION
Now that https://github.com/integr8ly/installation/pull/324 is verified we can set the `namespaces` flag to an empty value to scan all namespaces for prometheus resources.