### PR TITLE
INTLY-782 Add Prometheus Route resource

### DIFF
--- a/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
+++ b/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
@@ -153,7 +153,7 @@ func (r *ReconcileApplicationMonitoring) InstallPrometheusOperator(cr *applicati
 func (r *ReconcileApplicationMonitoring) CreatePrometheusCRs(cr *applicationmonitoringv1alpha1.ApplicationMonitoring) (reconcile.Result, error) {
 	log.Info("Phase: Create Prometheus CRs")
 
-	for _, resourceName := range []string{PrometheusServiceAccountName, PrometheusServiceName, PrometheusCrName} {
+	for _, resourceName := range []string{PrometheusServiceAccountName, PrometheusServiceName, PrometheusRouteName, PrometheusCrName} {
 		if err := r.CreateResource(cr, resourceName); err != nil {
 			log.Info(fmt.Sprintf("Error in CreatePrometheusCRs, resourceName=%s : err=%s", resourceName, err))
 			// Requeue so it can be attempted again

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -20,6 +20,7 @@ const (
 	PrometheusOperatorName               = "prometheus-operator"
 	PrometheusOperatorServiceAccountName = "prometheus-operator-service-account"
 	PrometheusCrName                     = "prometheus"
+	PrometheusRouteName                  = "prometheus-route"
 	PrometheusServiceAccountName         = "prometheus-service-account"
 	PrometheusServiceName                = "prometheus-service"
 	AlertManagerServiceAccountName       = "alertmanager-service-account"
@@ -42,6 +43,7 @@ type Parameters struct {
 	GrafanaOperatorRoleName        string
 	GrafanaOperatorRoleBindingName string
 	PrometheusCrName               string
+	PrometheusRouteName            string
 	PrometheusServiceName          string
 	AlertManagerServiceAccountName string
 	AlertManagerCrName             string
@@ -70,6 +72,7 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring) *Templat
 		PrometheusOperatorName:         PrometheusOperatorName,
 		ApplicationMonitoringName:      ApplicationMonitoringName,
 		PrometheusCrName:               PrometheusCrName,
+		PrometheusRouteName:            PrometheusRouteName,
 		PrometheusServiceName:          PrometheusServiceName,
 		AlertManagerServiceAccountName: AlertManagerServiceAccountName,
 		AlertManagerCrName:             AlertManagerCrName,

--- a/templates/prometheus-route.yaml
+++ b/templates/prometheus-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .PrometheusRouteName }}
+  namespace: {{ .Namespace }}
+spec:
+  port:
+    targetPort: web
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ .PrometheusServiceName }}
+  wildcardPolicy: None


### PR DESCRIPTION
Currently there is no Route created to expose the Prometheus dashboard
to the end-user. This means the end-user cannot access the Prometheus
dashboard.

This change adds a Route to the previously created Prometheus Service.

Verification:
- Create the various dependant CRDs and other OpenShift Resources.
- Run the operator.
- Ensure that a Route named 'prometheus-route' is created and resolves
to the Prometheus dashboard when opened.