### PR TITLE
add monitoring selector

### DIFF
--- a/templates/grafana.yaml
+++ b/templates/grafana.yaml
@@ -5,3 +5,6 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   prometheusUrl: "http://prometheus-service:9090"
+  monitoringNamespaceSelector:
+    matchLabels:
+      monitoring-key: middleware


### PR DESCRIPTION
Make sure the grafana operator is configured to watch only namespaces that match the label selector.