### PR TITLE
Fix serviceaccount name & operator permissions

### DIFF
--- a/deploy/roles/prometheus-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-clusterrole_binding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: prometheus-application-monitoring
 subjects:
 - kind: ServiceAccount
-  name: prometheus
+  name: prometheus-application-monitoring
   namespace: application-monitoring
 userNames:
-- system:serviceaccount:application-monitoring:prometheus
+- system:serviceaccount:application-monitoring:prometheus-application-monitoring

--- a/deploy/roles/prometheus-operator-clusterrole.yaml
+++ b/deploy/roles/prometheus-operator-clusterrole.yaml
@@ -45,10 +45,9 @@ rules:
   resources:
   - services
   - endpoints
+  - services/finalizers
   verbs:
-  - get
-  - create
-  - update
+  - "*"
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
These changes bring the cluster roles for prometheus & it's operator in line with what was tested for the integreatly installation.
