### PR TITLE
INTLY-1100 Inhibit duplicate alerts with different severity

### DIFF
--- a/templates/alertmanager-secret.yaml
+++ b/templates/alertmanager-secret.yaml
@@ -1,7 +1,27 @@
 apiVersion: v1
-data:
-  alertmanager.yaml: >-
-    Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogNW0Kcm91dGU6CiAgZ3JvdXBfd2FpdDogMzBzCiAgZ3JvdXBfaW50ZXJ2YWw6IDVtCiAgcmVwZWF0X2ludGVydmFsOiAxMmgKICByZWNlaXZlcjogZGVmYXVsdAogIHJvdXRlczoKICAtIG1hdGNoOgogICAgICBhbGVydG5hbWU6IERlYWRNYW5zU3dpdGNoCiAgICByZXBlYXRfaW50ZXJ2YWw6IDVtCiAgICByZWNlaXZlcjogZGVhZG1hbnNzd2l0Y2gKcmVjZWl2ZXJzOgotIG5hbWU6IGRlZmF1bHQKLSBuYW1lOiBkZWFkbWFuc3N3aXRjaAo=
+stringData:
+  alertmanager.yaml: |
+    global:
+      resolve_timeout: 5m
+    route:
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: default
+      routes:
+      - match:
+          alertname: DeadMansSwitch
+        repeat_interval: 5m
+        receiver: deadmansswitch
+    receivers:
+    - name: default
+    - name: deadmansswitch
+    inhibit_rules:
+    - source_match:
+        severity: 'critical'
+      target_match:
+        severity: 'warning'
+      equal: ['alertname']
 kind: Secret
 metadata:
   name: alertmanager-application-monitoring


### PR DESCRIPTION
An alert could escalate it's severity over time. For example, after
one minute of a Pod not existing an Alert with the Warning severity
could trigger, after five minutes an Alert with the Critical
severity would trigger. We shouldn't have both of these active in
AlertManager at the same time, instead we should inhibit the less
severe alert when the escalated alert triggers.

Verification:
- Deploy this branch of the operator
- The `alertmanager-application-monitoring` secret should contain
the `inhibit_rules` featured in this commit.
- Go to the PrometheusRule created in the namespace
- It should contain a DeadMansSwitch rule with severity None
- Change this to severity Warning
- Duplicate it with a severity Critical
- You should now see two Alerts in the Prometheus dashboard
- You should see one triggered Alert in AlertManager with the higher
severity (Critical).