### PR TITLE
Adding oauth-proxy sidecar to prometheus

### DIFF
--- a/deploy/roles/prometheus-clusterrole.yaml
+++ b/deploy/roles/prometheus-clusterrole.yaml
@@ -3,6 +3,18 @@ kind: ClusterRole
 metadata:
   name: prometheus-application-monitoring
 rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups: [""]
   resources:
   - nodes

--- a/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
+++ b/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
@@ -142,7 +142,7 @@ func (r *ReconcileApplicationMonitoring) Reconcile(request reconcile.Request) (r
 func (r *ReconcileApplicationMonitoring) InstallPrometheusOperator(cr *applicationmonitoringv1alpha1.ApplicationMonitoring) (reconcile.Result, error) {
 	log.Info("Phase: Install PrometheusOperator")
 
-	for _, resourceName := range []string{PrometheusOperatorServiceAccountName, PrometheusOperatorName} {
+	for _, resourceName := range []string{PrometheusOperatorServiceAccountName, PrometheusOperatorName, PrometheusProxySecretsName} {
 		if _, err := r.CreateResource(cr, resourceName); err != nil {
 			log.Info(fmt.Sprintf("Error in InstallPrometheusOperator, resourceName=%s : err=%s", resourceName, err))
 			// Requeue so it can be attempted again
@@ -168,7 +168,7 @@ func (r *ReconcileApplicationMonitoring) CreatePrometheusCRs(cr *applicationmoni
 		return reconcile.Result{Requeue: true}, err
 	}
 
-	for _, resourceName := range []string{PrometheusServiceAccountName, PrometheusServiceName, PrometheusRouteName, PrometheusCrName} {
+	for _, resourceName := range []string{PrometheusServiceAccountName, PrometheusServiceName, PrometheusCrName} {
 		if _, err := r.CreateResource(cr, resourceName); err != nil {
 			log.Info(fmt.Sprintf("Error in CreatePrometheusCRs, resourceName=%s : err=%s", resourceName, err))
 			// Requeue so it can be attempted again

--- a/templates/prometheus-proxy-secret.yaml
+++ b/templates/prometheus-proxy-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  session_secret: >-
+    {{.PrometheusSessionSecret}}
+kind: Secret
+metadata:
+  labels:
+    k8s-app: prometheus-k8s
+  name: prometheus-k8s-proxy
+  namespace: {{.Namespace }}
+type: Opaque

--- a/templates/prometheus-route.yaml
+++ b/templates/prometheus-route.yaml
@@ -7,7 +7,7 @@ spec:
   port:
     targetPort: web
   tls:
-    termination: edge
+    termination: Reencrypt
   to:
     kind: Service
     name: {{ .PrometheusServiceName }}

--- a/templates/prometheus-service-account.yaml
+++ b/templates/prometheus-service-account.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: prometheus-application-monitoring
   namespace: {{ .Namespace }}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ .PrometheusRouteName }}"}}'

--- a/templates/prometheus-service.yaml
+++ b/templates/prometheus-service.yaml
@@ -3,15 +3,17 @@ kind: Service
 metadata:
   name: {{ .PrometheusServiceName }}
   namespace: {{ .Namespace }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: prometheus-k8s-tls
   labels:
     application-monitoring: "true"
 spec:
   type: ClusterIP
   ports:
     - name: web
-      port: 9090
+      port: 9091
       protocol: TCP
-      targetPort: web
+      targetPort: oproxy
   selector:
     app: prometheus
   sessionAffinity: None

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -6,6 +6,34 @@ metadata:
   labels:
     prometheus: {{ .ApplicationMonitoringName }}
 spec:
+  containers:
+    - args:
+        - '-provider=openshift'
+        - '-https-address=:9091'
+        - '-http-address='
+        - '-email-domain=*'
+        - '-upstream=http://localhost:9090'
+        - '-openshift-service-account=prometheus-application-monitoring'
+        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb":"get"}}'
+        - '-tls-cert=/etc/tls/private/tls.crt'
+        - '-tls-key=/etc/tls/private/tls.key'
+        - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
+        - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
+        - '-openshift-ca=/etc/pki/tls/cert.pem'
+        - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        - '-skip-auth-regex=^/metrics'
+      image: 'registry.redhat.io/openshift3/oauth-proxy:v3.11.43'
+      name: prometheus-proxy
+      ports:
+        - containerPort: 9091
+          name: oproxy
+      resources: {}
+      volumeMounts:
+        - mountPath: /etc/tls/private
+          name: secret-prometheus-k8s-tls
+        - mountPath: /etc/proxy/secrets
+          name: secret-prometheus-k8s-proxy
   externalUrl: https://{{ index .ExtraParams "prometheusHost" }}
   alerting:
     alertmanagers:
@@ -15,6 +43,9 @@ spec:
   resources:
     requests:
       memory: 400Mi
+  secrets:
+    - prometheus-k8s-tls
+    - prometheus-k8s-proxy
   serviceAccountName: prometheus-application-monitoring
   serviceMonitorNamespaceSelector:
     matchLabels:


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-619

Prometheus: Add OAuth Proxy login so the various consoles are not accessible to unauthenticated users.

Verification steps on integreatly cluster:

- In the application-monitoring-operator directory on this branch:

```
oc new-project application-monitoring
oc label namespace application-monitoring monitoring-key=middleware
oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/Grafana.yaml
oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/GrafanaDashboard.yaml
oc apply -f ./deploy/roles
oc apply -f ./deploy/operator_roles/
oc apply -f ./deploy/crds/ApplicationMonitoring.yaml
oc apply -f ./deploy/operator.yaml
oc apply -f ./deploy/examples/ApplicationMonitoring.yaml
```
- Scale down the Application Monitoring Operator in the "Managed Service Monitoring" namespace, and scale down the Application Monitoring Operator in the "application monitoring" namespace
- Run the Application monitoring Operator locally `operator-sdk up local --namespace application-monitoring`
- Delete the ApplicationMonitoring custom resource: `oc delete applicationmonitorings example-applicationmonitoring`
- Redeploy everything `oc apply -f ./deploy/examples/ApplicationMonitoring.yaml` using the operator running locally
- Once finished, expect to see unique values in the following secrets: `prometheus-k8s-proxy`
- Logging into the Prometheus dashboard should allow you to authenticate via openshift and prevent you accessing the dashboard otherwise
