### PR TITLE
use red hat grafana image

### DIFF
--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -70,7 +70,7 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 		GrafanaCrName:                  GrafanaCrName,
 		GrafanaOperatorRoleBindingName: GrafanaOperatorRoleBindingName,
 		GrafanaOperatorRoleName:        GrafanaOperatorRoleName,
-		GrafanaImage:                   "quay.io/integreatly/grafana-operator:0.0.1",
+		GrafanaImage:                   "quay.io/integreatly/grafana-operator:0.0.2",
 		PrometheusOperatorName:         PrometheusOperatorName,
 		ApplicationMonitoringName:      ApplicationMonitoringName,
 		PrometheusCrName:               PrometheusCrName,

--- a/templates/grafana-operator.yaml
+++ b/templates/grafana-operator.yaml
@@ -17,6 +17,9 @@ spec:
       containers:
         - name: {{ .GrafanaOperatorName }}
           image: {{ .GrafanaImage }}
+          args:
+            - '--grafana-image=registry.redhat.io/openshift3/grafana'
+            - '--grafana-image-tag=v3.11'
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Update to the latest version of the grafana operator that allows overriding the grafana image.

Also sets the image to the supported RH one.