### PR TITLE
remove monitoring key env var

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,8 +33,6 @@ spec:
           env:
             - name: TEMPLATE_PATH
               value: /usr/local/bin/templates
-            - name: MONITORING_KEY
-              value: middleware
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
The monitoring key is now passed in with the CR. This env var can still be used to override it, but we don't need it for our use case.