### PR TITLE
oauth-proxy fronting AlertManager

### DIFF
--- a/deploy/roles/alertmanager-clusterrole.yaml
+++ b/deploy/roles/alertmanager-clusterrole.yaml
@@ -5,14 +5,12 @@ metadata:
 rules:
 - apiGroups:
   - authentication.k8s.io
-  attributeRestrictions: null
   resources:
   - tokenreviews
   verbs:
   - create
 - apiGroups:
   - authorization.k8s.io
-  attributeRestrictions: null
   resources:
   - subjectaccessreviews
   verbs:

--- a/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
+++ b/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
@@ -194,7 +194,7 @@ func (r *ReconcileApplicationMonitoring) CreateAlertManagerCRs(cr *applicationmo
 		return reconcile.Result{Requeue: true}, err
 	}
 
-	for _, resourceName := range []string{AlertManagerServiceAccountName, AlertManagerServiceName, AlertManagerSecretName, AlertManagerCrName} {
+	for _, resourceName := range []string{AlertManagerServiceAccountName, AlertManagerServiceName, AlertManagerSecretName, AlertManagerProxySecretsName, AlertManagerCrName} {
 		if _, err := r.CreateResource(cr, resourceName); err != nil {
 			log.Info(fmt.Sprintf("Error in CreateAlertManagerCRs, resourceName=%s : err=%s", resourceName, err))
 			// Requeue so it can be attempted again

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -26,6 +26,7 @@ const (
 	PrometheusProxySecretsName           = "prometheus-proxy-secret"
 	PrometheusServiceAccountName         = "prometheus-service-account"
 	PrometheusServiceName                = "prometheus-service"
+	AlertManagerProxySecretsName         = "alertmanager-proxy-secret"
 	AlertManagerServiceAccountName       = "alertmanager-service-account"
 	AlertManagerCrName                   = "alertmanager"
 	AlertManagerServiceName              = "alertmanager-service"
@@ -49,6 +50,7 @@ type Parameters struct {
 	PrometheusRouteName            string
 	PrometheusServiceName          string
 	PrometheusSessionSecret        string
+	AlertManagerSessionSecret      string
 	AlertManagerServiceAccountName string
 	AlertManagerCrName             string
 	AlertManagerServiceName        string
@@ -80,7 +82,8 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 		PrometheusCrName:               PrometheusCrName,
 		PrometheusRouteName:            PrometheusRouteName,
 		PrometheusServiceName:          PrometheusServiceName,
-		PrometheusSessionSecret:        PopulatePrometheusProxySecret(),
+		PrometheusSessionSecret:        PopulateSessionProxySecret(),
+		AlertManagerSessionSecret:      PopulateSessionProxySecret(),
 		AlertManagerServiceAccountName: AlertManagerServiceAccountName,
 		AlertManagerCrName:             AlertManagerCrName,
 		AlertManagerServiceName:        AlertManagerServiceName,
@@ -108,10 +111,10 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 }
 
 // Populate the PrometheusServiceName values
-func PopulatePrometheusProxySecret() string {
+func PopulateSessionProxySecret() string {
 	p, err := GeneratePassword(43)
 	if err != nil {
-		log.Info("Error creating PopulatePrometheusProxySecret")
+		log.Info("Error executing PopulateSessionProxySecret")
 	}
 	return p
 }

--- a/templates/alertmanager-proxy-secret.yaml
+++ b/templates/alertmanager-proxy-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  session_secret: >-
+    {{.AlertManagerSessionSecret}}
+kind: Secret
+metadata:
+  labels:
+    k8s-app: alertmanager-k8s
+  name: alertmanager-k8s-proxy
+  namespace: {{.Namespace }}
+type: Opaque

--- a/templates/alertmanager-route.yaml
+++ b/templates/alertmanager-route.yaml
@@ -7,7 +7,7 @@ spec:
   port:
     targetPort: web
   tls:
-    termination: edge
+    termination: Reencrypt
   to:
     kind: Service
     name: {{ .AlertManagerServiceName }}

--- a/templates/alertmanager-service-account.yaml
+++ b/templates/alertmanager-service-account.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: alertmanager
   namespace: {{ .Namespace }}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ .AlertManagerRouteName }}"}}'

--- a/templates/alertmanager-service.yaml
+++ b/templates/alertmanager-service.yaml
@@ -3,12 +3,14 @@ kind: Service
 metadata:
   name: {{ .AlertManagerServiceName }}
   namespace: {{ .Namespace }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: alertmanager-k8s-tls
 spec:
   ports:
     - name: web
-      port: 6783
+      port: 9091
       protocol: TCP
-      targetPort: web
+      targetPort: oproxy
   selector:
     alertmanager: {{ .ApplicationMonitoringName }}
     app: alertmanager

--- a/templates/alertmanager.yaml
+++ b/templates/alertmanager.yaml
@@ -7,3 +7,38 @@ spec:
   externalUrl: https://{{ index .ExtraParams "alertmanagerHost" }}
   listenLocal: false
   serviceAccountName: alertmanager
+  containers:
+    - args:
+        - '-provider=openshift'
+        - '-https-address=:9091'
+        - '-http-address='
+        - '-email-domain=*'
+        - '-upstream=http://localhost:9093'
+        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+        - '-tls-cert=/etc/tls/private/tls.crt'
+        - '-tls-key=/etc/tls/private/tls.key'
+        - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
+        - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
+        - '-openshift-service-account=alertmanager'
+        - '-openshift-ca=/etc/pki/tls/cert.pem'
+        - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        - '-skip-auth-regex=^/metrics'
+      env:
+        - name: HTTP_PROXY
+        - name: HTTPS_PROXY
+        - name: NO_PROXY
+      image: 'registry.redhat.io/openshift3/oauth-proxy:v3.11.43'
+      name: alertmanager-proxy
+      ports:
+        - containerPort: 9091
+          name: oproxy
+      resources: {}
+      volumeMounts:
+        - mountPath: /etc/tls/private
+          name: secret-alertmanager-k8s-tls
+        - mountPath: /etc/proxy/secrets
+          name: secret-alertmanager-k8s-proxy
+  secrets:
+    - alertmanager-k8s-tls
+    - alertmanager-k8s-proxy


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-619

AlertManager: Add OAuth Proxy login so the various consoles are not accessible to unauthenticated users.

Verification steps on integreatly cluster:

- In the application-monitoring-operator directory on this branch:

```
oc new-project application-monitoring
oc label namespace application-monitoring monitoring-key=middleware
oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/Grafana.yaml
oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/GrafanaDashboard.yaml
oc apply -f ./deploy/roles
oc apply -f ./deploy/operator_roles/
oc apply -f ./deploy/crds/ApplicationMonitoring.yaml
oc apply -f ./deploy/operator.yaml
oc apply -f ./deploy/examples/ApplicationMonitoring.yaml
```
- Scale down the Application Monitoring Operator in the "Managed Service Monitoring" namespace, and scale down the Application Monitoring Operator in the "application monitoring" namespace
- Run the Application monitoring Operator locally `operator-sdk up local --namespace application-monitoring`
- Delete the ApplicationMonitoring custom resource: `oc delete applicationmonitorings example-applicationmonitoring -n application-monitoring`
- Redeploy everything `oc apply -f ./deploy/examples/ApplicationMonitoring.yaml  -n application-monitoring` using the operator running locally
- Once finished, expect to see unique values in the following secrets: `prometheus-k8s-proxy`
- Logging into the AlertManager dashboard should allow you to authenticate via openshift and prevent you accessing the dashboard otherwise
