### PR TITLE
fix: Add applicationmonitoring.integreatly.org to operator role

### DIFF
--- a/deploy/operator_roles/role.yaml
+++ b/deploy/operator_roles/role.yaml
@@ -37,10 +37,17 @@ rules:
   - get
   - create
 - apiGroups:
-  - integreatly.org
+  - applicationmonitoring.integreatly.org
   resources:
+  - applicationmonitorings
+  - applicationmonitorings/finalizers
   - blackboxtargets
   - blackboxtargets/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - integreatly.org
+  resources:
   - grafanadatasources
   - grafanadashboards
   - grafanas


### PR DESCRIPTION
Updating the operator role to include the `applicationmonitoring.integreatly.org` apiGroup.  This was removed https://github.com/integr8ly/application-monitoring-operator/pull/60/files#diff-ae50e2319c2adea5d52ec9b2bbd25a5eL39 but shouldn't have been.