### PR TITLE
use matchExpressions

### DIFF
--- a/templates/grafana.yaml
+++ b/templates/grafana.yaml
@@ -49,7 +49,7 @@ spec:
     - grafana-k8s-tls
     - grafana-k8s-proxy
   dashboardLabelSelector:
-    - matchLabels:
-        monitoring-key: {{ .MonitoringKey }}
+    - matchExpressions:
+      - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
     - matchLabels:
         app: syndesis

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -70,17 +70,17 @@ spec:
     - {{ .BlackboxExporterConfigmapName }}
   serviceAccountName: prometheus-application-monitoring
   serviceMonitorNamespaceSelector:
-    matchLabels:
-      monitoring-key: {{ .MonitoringKey }}
+    matchExpressions:
+      - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
   serviceMonitorSelector:
-    matchLabels:
-      monitoring-key: {{ .MonitoringKey }}
+    matchExpressions:
+      - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
   ruleSelector:
-    matchLabels:
-      monitoring-key: {{ .MonitoringKey }}
+    matchExpressions:
+      - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
   ruleNamespaceSelector:
-    matchLabels:
-      monitoring-key: {{ .MonitoringKey }}
+    matchExpressions:
+      - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
   additionalScrapeConfigs:
     name: {{ .ScrapeConfigSecretName }}
     key: integreatly.yaml


### PR DESCRIPTION
Changes matchLabels selectors to matchExpressions selectors.

To validate:
* Change `labelSelector: "middleware"` in deploy/example/ApplicationMonitoring.yaml to `labelselector:"middleware,< second-label >"
* Change the lables on some namespaces from `monitoring_key: middleware` to `monitoring-key: < second-label >`
* create ApplicationMonitoring cr and wait for stack to deploy
* Validate that the yaml in the prometheus and grafana crs have been parsed correctly
* Validate that prometheus is scraping from any namespaces with a matching < second-label > label

Closes #63