### PR TITLE
Fix cluster/clean target & install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,24 @@ test/e2e:
 cluster/prepare:
 	-kubectl apply -f deploy/crds/
 	-oc new-project $(NAMESPACE)
-	-kubectl create --insecure-skip-tls-verify -f deploy/rbac.yaml -n $(NAMESPACE)
 
 .PHONY: cluster/clean
 cluster/clean:
-	-kubectl delete role application-monitoring-operator -n $(NAMESPACE)
-	-kubectl delete rolebinding application-monitoring-operator -n $(NAMESPACE)
-	-kubectl delete crd application-monitorings.integreatly.org
+	-kubectl delete -n $(NAMESPACE) --all blackboxtargets
+	-kubectl delete -n $(NAMESPACE) --all grafanadashboards
+	-kubectl delete -n $(NAMESPACE) --all grafanadatasources
+	-kubectl delete -n $(NAMESPACE) --all applicationmonitorings
+	-kubectl delete -f ./deploy/roles
+	-kubectl delete crd grafanas.integreatly.org
+	-kubectl delete crd grafanadashboards.integreatly.org
+	-kubectl delete crd grafanadatasources.integreatly.org
+	-kubectl delete crd podmonitors.monitoring.coreos.com
+	-kubectl delete crd prometheuses.monitoring.coreos.com
+	-kubectl delete crd alertmanagers.monitoring.coreos.com
+	-kubectl delete crd prometheusrules.monitoring.coreos.com
+	-kubectl delete crd servicemonitors.monitoring.coreos.com
+	-kubectl delete crd blackboxtargets.applicationmonitoring.integreatly.org
+	-kubectl delete crd applicationmonitorings.applicationmonitoring.integreatly.org
 	-kubectl delete namespace $(NAMESPACE)
 
 .PHONY: cluster/create/examples

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,11 @@ oc label namespace application-monitoring monitoring-key=middleware
 oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/Grafana.yaml
 oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/GrafanaDashboard.yaml
 oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/GrafanaDataSource.yaml
+oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/podmonitor.crd.yaml
+oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheus.crd.yaml
+oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/alertmanager.crd.yaml
+oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml
+oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml
 
 # BlackboxTarget
 oc apply -f ./deploy/crds/BlackboxTarget.yaml
@@ -18,8 +23,14 @@ oc apply -f ./deploy/crds/ApplicationMonitoring.yaml
 
 # Cluster Roles & RoleBindings
 oc apply -f ./deploy/roles
-oc apply -f ./deploy/operator_roles/
+oc apply -f ./deploy/operator_roles/service_account.yaml
+oc apply -f ./deploy/operator_roles/role.yaml
+oc apply -f ./deploy/operator_roles/role_binding.yaml
 
 # AMO Deployment
+until oc auth can-i create prometheus -n application-monitoring --as system:serviceaccount:application-monitoring:application-monitoring-operator; do
+    echo "Waiting for all CRDs and SA permissions to be applied before deploying operator..." && sleep 1
+done
+
 oc apply -f ./deploy/operator.yaml
 oc apply -f ./deploy/examples/ApplicationMonitoring.yaml

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,28 +4,32 @@
 oc new-project application-monitoring
 oc label namespace application-monitoring monitoring-key=middleware
 
+# Application Monitoring Operator
+# AMO CRD
+oc apply -f ./deploy/crds/ApplicationMonitoring.yaml
+
+# AMO Cluster Roles & RoleBindings
+oc apply -f ./deploy/roles
+oc apply -f ./deploy/operator_roles/service_account.yaml
+oc apply -f ./deploy/operator_roles/role.yaml
+oc apply -f ./deploy/operator_roles/role_binding.yaml
+
+# BlackboxTarget
+oc apply -f ./deploy/crds/BlackboxTarget.yaml
+
 # Grafana CRDs
 oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/Grafana.yaml
 oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/GrafanaDashboard.yaml
 oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/crds/GrafanaDataSource.yaml
+
+# Prometheus CRDs
 oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/podmonitor.crd.yaml
 oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheus.crd.yaml
 oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/alertmanager.crd.yaml
 oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml
 oc apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml
 
-# BlackboxTarget
-oc apply -f ./deploy/crds/BlackboxTarget.yaml
 
-# Application Monitoring Operator
-# AMO CRD
-oc apply -f ./deploy/crds/ApplicationMonitoring.yaml
-
-# Cluster Roles & RoleBindings
-oc apply -f ./deploy/roles
-oc apply -f ./deploy/operator_roles/service_account.yaml
-oc apply -f ./deploy/operator_roles/role.yaml
-oc apply -f ./deploy/operator_roles/role_binding.yaml
 
 # AMO Deployment
 until oc auth can-i create prometheus -n application-monitoring --as system:serviceaccount:application-monitoring:application-monitoring-operator; do


### PR DESCRIPTION
Locally in minishift I've found that when the AMO starts & reacts to
the CR, errors are thrown about the prometheus kinds not being
found. This appears to be because, well, they didn't exist when it
started (they're created by the prometheus operator?), and the AMO
can't find them in its cache probably.

I also noticed errors being ignored about the role/rolebinding being
done in the wrong order, but execution continues anyway, so I've just
explicitly put them in the right order, and also put in a simple check
to make sure that the SA has the right access.

I also updated the cluster/clean target since that was broken in a
couple of ways before (causing the namespace to be undeletable without
figuring out what in there had a finalizer and cleaning it up). Also
the cluster/prepare was referencing a file that didn't exist.