### PR TITLE
INTLY-817: increasing Prometheus log level to decrease excessive logging

### DIFF
--- a/templates/prometheus-operator.yaml
+++ b/templates/prometheus-operator.yaml
@@ -19,6 +19,7 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --logtostderr=true
+            - -log-level=warn 
             - --config-reloader-image={{ .ImageConfigMapReloader }}:{{ .ImageTagConfigMapReloader }}
             - --prometheus-config-reloader={{ .ImagePrometheusConfigReloader }}:{{ .ImageTagPrometheusConfigReloader }}
             - --namespaces=


### PR DESCRIPTION
### Motivation
Removing excessive logging of the prometheus-operator

### What
Increasing log level to warn, 

### Why
We probably don't need to have Info level stuff in our logs, it causes this log flooding.

### Checklist:
- [x]  Code has been tested locally by PR requester
- [ ]  Changes have been successfully verified by another team member

### Notes
Tested on minishift only, not full integr8ly install.

It's a sort of a quick and dirty fix...
As mentioned in https://github.com/coreos/prometheus-operator/issues/1966. There is PR open for moving this logging to DEBUG level. But there is probably a bigger problem of executing this syncing stuff too often, so there may be a another fix in the future.