### PR TITLE
INTLY-3813 - Don't watch `openshift-monitoring`ns

### DIFF
--- a/templates/prometheus-operator.yaml
+++ b/templates/prometheus-operator.yaml
@@ -22,7 +22,7 @@ spec:
             - -log-level=warn 
             - --config-reloader-image={{ .ImageConfigMapReloader }}:{{ .ImageTagConfigMapReloader }}
             - --prometheus-config-reloader={{ .ImagePrometheusConfigReloader }}:{{ .ImageTagPrometheusConfigReloader }}
-            - --namespaces=
+            - --deny-namespaces=openshift-monitoring
           image: {{ .ImagePrometheusOperator }}:{{ .ImageTagPrometheusOperator }}
           name: prometheus-application-operator
           ports:


### PR DESCRIPTION
https://issues.jboss.org/browse/INTLY-3813

In an openshift cluster where another instance of the prometheus-operator is running (typically in `openshift-monitoring` ns), there is a problem where the operator instance created by the application monitoring operator will try to maintain certain resources in the other ns too. 
This causes problems if they are at different versions.
For example, the application monitoring  prometheus-operator instance will reconcile the prometheus secret in the `openshift-monitoring` ns to what it thinks it should be. Then the prometheus-operator in the `openshift-monitoring` namespace will change it back.

The application monitoring prometheus-operator shouldn't do anything with the `openshift-monitoring` namespace at all.
This change ensures that.