### PR TITLE
Bumping grafana operator version to v1.3.2

### DIFF
--- a/deploy/roles/alertmanager-clusterrole_binding.yaml
+++ b/deploy/roles/alertmanager-clusterrole_binding.yaml
@@ -7,7 +7,7 @@ roleRef:
   name: alertmanager-application-monitoring
 subjects:
 - kind: ServiceAccount
-  name: alertmanager
+  name: alertmanager-service-account
   namespace: application-monitoring
 userNames:
-- system:serviceaccount:application-monitoring:alertmanager
+- system:serviceaccount:application-monitoring:alertmanager-service-account

--- a/deploy/roles/prometheus-clusterrole_binding.yaml
+++ b/deploy/roles/prometheus-clusterrole_binding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: prometheus-application-monitoring
 subjects:
 - kind: ServiceAccount
-  name: prometheus-application-monitoring
+  name: prometheus-service-account
   namespace: application-monitoring
 userNames:
-- system:serviceaccount:application-monitoring:prometheus-application-monitoring
+- system:serviceaccount:application-monitoring:prometheus-service-account

--- a/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
+++ b/pkg/controller/applicationmonitoring/applicationmonitoring_controller.go
@@ -208,7 +208,7 @@ func (r *ReconcileApplicationMonitoring) ensureServiceAccountHasOauthAnnotation(
 		if len(instance.Annotations) == 0 {
 			instance.Annotations = map[string]string{}
 		}
-		instance.Annotations[key] = fmt.Sprintf("'{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"%s\"}}'", route)
+		instance.Annotations[key] = fmt.Sprintf("{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"%s\"}}", route)
 
 		err = r.client.Update(context.TODO(), instance)
 		if err != nil {

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -141,7 +141,7 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 		ImageGrafana:                     "quay.io/openshift/origin-grafana",
 		ImageTagGrafana:                  "4.2",
 		ImageGrafanaOperator:             "quay.io/integreatly/grafana-operator",
-		ImageTagGrafanaOperator:          "v1.3.1",
+		ImageTagGrafanaOperator:          "v1.3.2",
 		ImageConfigMapReloader:           "quay.io/openshift/origin-configmap-reloader",
 		ImageTagConfigMapReloader:        "4.2",
 		ImagePrometheusConfigReloader:    "quay.io/openshift/origin-prometheus-config-reloader",

--- a/templates/grafana-operator.yaml
+++ b/templates/grafana-operator.yaml
@@ -1,32 +1,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .GrafanaOperatorName }}
+  name: "{{ .GrafanaOperatorName }}"
   namespace: {{ .Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: {{ .GrafanaOperatorName }}
+      name: "{{ .GrafanaOperatorName }}"
   template:
     metadata:
       labels:
-        name: {{ .GrafanaOperatorName }}
+        name: "{{ .GrafanaOperatorName }}"
     spec:
       serviceAccountName: grafana-operator
       containers:
-        - name: {{ .GrafanaOperatorName }}
-          image: {{ .ImageGrafanaOperator }}:{{ .ImageTagGrafanaOperator }}
+        - name: "{{ .GrafanaOperatorName }}"
+          image: "{{ .ImageGrafanaOperator }}:{{ .ImageTagGrafanaOperator }}"
           args:
             - '--grafana-image={{ .ImageGrafana }}'
             - '--grafana-image-tag={{ .ImageTagGrafana }}'
-            - '--openshift'
             - '--scan-all'
           ports:
           - containerPort: 60000
             name: metrics
           command:
-          - {{ .GrafanaOperatorName }}
+          - "{{ .GrafanaOperatorName }}"
           imagePullPolicy: Always
           readinessProbe:
             exec:

--- a/templates/grafana-operator.yaml
+++ b/templates/grafana-operator.yaml
@@ -20,6 +20,7 @@ spec:
           args:
             - '--grafana-image={{ .ImageGrafana }}'
             - '--grafana-image-tag={{ .ImageTagGrafana }}'
+            - '--openshift'
             - '--scan-all'
           ports:
           - containerPort: 60000


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-3843

Related PRs:
- https://github.com/integr8ly/manifests/pull/75
- https://github.com/integr8ly/application-monitoring-operator/pull/87
- https://github.com/integr8ly/application-monitoring-operator/pull/88
- https://github.com/integr8ly/integreatly-operator/pull/142
- https://github.com/integr8ly/installation/pull/1075/files
- https://github.com/integr8ly/grafana-operator/pull/57

Periodically reconcile the service accounts for Grafana, Prometheus and AlertManager to make sure the annotations are in place.

Bumping integreatly operator version 1.9.5
Bumping application monitoring operator version 0.0.28
Bumping grafana operator version 1.3.2


### Verification:

- Checkout the codebase from my fork/branch: ``https://github.com/davidkirwan/application-monitoring-operator.git`` and branch ``amo_route_grafana_fix``
- Create namespace ``application-monitoring``
- Apply the crds ``oc apply -f deploy/crds``
- Apply the roles ``oc apply -f deploy/roles``
- Apply the crds from the Grafana operator: 
```
oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/v1.3/deploy/crds/Grafana.yaml
oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/v1.3/deploy/crds/GrafanaDashboard.yaml
oc apply -f https://raw.githubusercontent.com/integr8ly/grafana-operator/v1.3/deploy/crds/GrafanaDataSource.yaml
```
- Run the operator locally against your cluster: ``operator-sdk up local --namespace "application-monitoring"``
- Create the ApplicationMonitoring CR: ``oc apply -f deploy/examples/ApplicationMonitoring.yaml``
- Wait for the resources to deploy, grafana should be last.
- Visit the 3 routes, ``grafana-route`` ``prometheus-route`` and ``alertmanger-route`` authenticate via oauth, and the dashboards should successfully load.