### PR TITLE
Intly 3920

### DIFF
--- a/deploy/crds/ApplicationMonitoring.yaml
+++ b/deploy/crds/ApplicationMonitoring.yaml
@@ -34,3 +34,9 @@ spec:
             prometheusStorageRequest:
               type: string
               description: How much storage to assign to a volume claim for persisting Prometheus data. See https://github.com/coreos/prometheus-operator/blob/ca400fdc3edd0af0df896a338eca270e115b74d7/Documentation/api.md#storagespec
+            prometheusInstanceNamespaces:
+              type: string
+              description: The list of namespaces to watch for prometheus custom resources
+            alertmanagerInstanceNamespaces:
+              type: string
+              description: The list of namespaces to watch for alertmanager custom resources

--- a/deploy/examples/ApplicationMonitoring.yaml
+++ b/deploy/examples/ApplicationMonitoring.yaml
@@ -8,3 +8,5 @@ spec:
   additionalScrapeConfigSecretKey: "integreatly-additional.yaml"
   prometheusRetention: 15d
   prometheusStorageRequest: 10Gi
+  prometheusInstanceNamespaces: middleware-monitoring
+  alertmanagerInstanceNamespaces: middleware-monitoring

--- a/deploy/examples/ApplicationMonitoring.yaml
+++ b/deploy/examples/ApplicationMonitoring.yaml
@@ -8,5 +8,5 @@ spec:
   additionalScrapeConfigSecretKey: "integreatly-additional.yaml"
   prometheusRetention: 15d
   prometheusStorageRequest: 10Gi
-  prometheusInstanceNamespaces: middleware-monitoring
-  alertmanagerInstanceNamespaces: middleware-monitoring
+  prometheusInstanceNamespaces: application-monitoring
+  alertmanagerInstanceNamespaces: application-monitoring

--- a/pkg/apis/applicationmonitoring/v1alpha1/applicationmonitoring_types.go
+++ b/pkg/apis/applicationmonitoring/v1alpha1/applicationmonitoring_types.go
@@ -16,6 +16,8 @@ type ApplicationMonitoringSpec struct {
 	AdditionalScrapeConfigSecretKey  string `json:"additionalScrapeConfigSecretKey,omitempty"`
 	PrometheusRetention              string `json:"prometheusRetention,omitempty"`
 	PrometheusStorageRequest         string `json:"prometheusStorageRequest,omitempty"`
+	PrometheusInstanceNamespaces     string `json:"prometheusInstanceNamespaces, omitempty"`
+	AlertmanagerInstanceNamespaces   string `json:"alertmanagerInstanceNamespaces, omitempty"`
 }
 
 // ApplicationMonitoringStatus defines the observed state of ApplicationMonitoring

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -94,8 +94,8 @@ type Parameters struct {
 	BlackboxTargets                  []applicationmonitoring.BlackboxtargetData
 	PrometheusRetention              string
 	PrometheusStorageRequest         string
-	PrometheusInstanceNamespaces	 string
-	AlertmanagerInstanceNamespaces	 string
+	PrometheusInstanceNamespaces     string
+	AlertmanagerInstanceNamespaces   string
 	ExtraParams                      map[string]string
 }
 
@@ -156,7 +156,7 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 		ImageTagBlackboxExporter:         "v0.14.0",
 		PrometheusRetention:              cr.Spec.PrometheusRetention,
 		PrometheusStorageRequest:         cr.Spec.PrometheusStorageRequest,
-		PrometheusInstanceNamespaces:	  cr.Spec.PrometheusInstanceNamespaces,
+		PrometheusInstanceNamespaces:     cr.Spec.PrometheusInstanceNamespaces,
 		AlertmanagerInstanceNamespaces:   cr.Spec.AlertmanagerInstanceNamespaces,
 		ExtraParams:                      extraParams,
 	}

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -94,6 +94,8 @@ type Parameters struct {
 	BlackboxTargets                  []applicationmonitoring.BlackboxtargetData
 	PrometheusRetention              string
 	PrometheusStorageRequest         string
+	PrometheusInstanceNamespaces	 string
+	AlertmanagerInstanceNamespaces	 string
 	ExtraParams                      map[string]string
 }
 
@@ -147,13 +149,15 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 		ImagePrometheusConfigReloader:    "quay.io/openshift/origin-prometheus-config-reloader",
 		ImageTagPrometheusConfigReloader: "4.2",
 		ImagePrometheusOperator:          "quay.io/coreos/prometheus-operator",
-		ImageTagPrometheusOperator:       "v0.33.0",
+		ImageTagPrometheusOperator:       "v0.34.0",
 		ImagePrometheus:                  "quay.io/openshift/origin-prometheus",
 		ImageTagPrometheus:               "4.2",
 		ImageBlackboxExporter:            "quay.io/prometheus/blackbox-exporter",
 		ImageTagBlackboxExporter:         "v0.14.0",
 		PrometheusRetention:              cr.Spec.PrometheusRetention,
 		PrometheusStorageRequest:         cr.Spec.PrometheusStorageRequest,
+		PrometheusInstanceNamespaces:	  cr.Spec.PrometheusInstanceNamespaces,
+		AlertmanagerInstanceNamespaces:   cr.Spec.AlertmanagerInstanceNamespaces,
 		ExtraParams:                      extraParams,
 	}
 

--- a/templates/prometheus-operator.yaml
+++ b/templates/prometheus-operator.yaml
@@ -24,7 +24,7 @@ spec:
             - --prometheus-config-reloader={{ .ImagePrometheusConfigReloader }}:{{ .ImageTagPrometheusConfigReloader }}
             - --prometheus-instance-namespaces={{ .PrometheusInstanceNamespaces }}
             - --alertmanager-instance-namespaces={{ .AlertmanagerInstanceNamespaces }}
-          image: {{ .ImagePrometheusOperator }}:master
+          image: {{ .ImagePrometheusOperator }}:{{ .ImageTagPrometheusOperator }}
           name: prometheus-application-operator
           ports:
             - containerPort: 8080

--- a/templates/prometheus-operator.yaml
+++ b/templates/prometheus-operator.yaml
@@ -22,8 +22,9 @@ spec:
             - -log-level=warn 
             - --config-reloader-image={{ .ImageConfigMapReloader }}:{{ .ImageTagConfigMapReloader }}
             - --prometheus-config-reloader={{ .ImagePrometheusConfigReloader }}:{{ .ImageTagPrometheusConfigReloader }}
-            - --deny-namespaces=openshift-monitoring,openshift-apiserver-operator,openshift-authentication,openshift-authentication-operator,openshift-controller-manager,openshift-controller-manager-operator,openshift-dns,openshift-image-registry,openshift-ingress,openshift-kube-apiserver-operator,openshift-kube-controller-manager-operator,openshift-operator-lifecycle-manager,openshift-sdn,openshift-service-catalog-controller-manager-operator
-          image: {{ .ImagePrometheusOperator }}:{{ .ImageTagPrometheusOperator }}
+            - --prometheus-instance-namespaces={{ .PrometheusInstanceNamespaces }}
+            - --alertmanager-instance-namespaces={{ .AlertmanagerInstanceNamespaces }}
+          image: {{ .ImagePrometheusOperator }}:master
           name: prometheus-application-operator
           ports:
             - containerPort: 8080

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.28"
+	Version = "0.0.29"
 )


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-3920

Add the prometheus/alertmanager-isntance-namespaces flags to allow the prometheus operator to define which namespaces to watch for custom resources.
