### PR TITLE
Add all perms for CRs in AMO namespace to AMO serviceaccount

### DIFF
--- a/deploy/operator_roles/role.yaml
+++ b/deploy/operator_roles/role.yaml
@@ -34,8 +34,7 @@ rules:
   - prometheusrules
   - servicemonitors
   verbs:
-  - get
-  - create
+  - '*'
 - apiGroups:
   - applicationmonitoring.integreatly.org
   resources:


### PR DESCRIPTION
Since AMO now lists and potentially updates CR's it owns, it needs more permissions