### PR TITLE
Intly 4255

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAMESPACE ?= application-monitoring
 PROJECT ?= application-monitoring-operator
 REG=quay.io
 SHELL=/bin/bash
-TAG ?= 1.0.0
+TAG ?= 1.0.1
 PKG=github.com/integr8ly/application-monitoring-operator
 TEST_DIRS?=$(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go -exec dirname {} \\; | sort | uniq")
 TEST_POD_NAME=application-monitoring-operator-test
@@ -13,7 +13,7 @@ COMPILE_TARGET=./tmp/_output/bin/$(PROJECT)
 # If you are updating this verion you will need to update the file names in ./scripts/install.sh too
 # You can delete this comment afterwards.
 PROMETHEUS_OPERATOR_VERSION=v0.34.0
-GRAFANA_OPERATOR_VERSION=v3.0.0
+GRAFANA_OPERATOR_VERSION=v3.0.1
 
 
 .PHONY: setup/dep

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: application-monitoring-operator
       containers:
         - name: application-monitoring-operator
-          image: quay.io/integreatly/application-monitoring-operator:1.0.0
+          image: quay.io/integreatly/application-monitoring-operator:1.0.1
           ports:
             - containerPort: 60000
               name: metrics

--- a/deploy/roles/prometheus-clusterrole.yaml
+++ b/deploy/roles/prometheus-clusterrole.yaml
@@ -25,6 +25,7 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
+  - namespaces # Required to get through the alertmanager oauth proxy
   verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]

--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -143,7 +143,7 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 		ImageGrafana:                     "quay.io/openshift/origin-grafana",
 		ImageTagGrafana:                  "4.2",
 		ImageGrafanaOperator:             "quay.io/integreatly/grafana-operator",
-		ImageTagGrafanaOperator:          "v3.0.0",
+		ImageTagGrafanaOperator:          "v3.0.1",
 		ImageConfigMapReloader:           "quay.io/openshift/origin-configmap-reloader",
 		ImageTagConfigMapReloader:        "4.2",
 		ImagePrometheusConfigReloader:    "quay.io/openshift/origin-prometheus-config-reloader",

--- a/templates/grafana-operator-service-account.yaml
+++ b/templates/grafana-operator-service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana-operator
-  namespace: {{ .Namespace }}
+  namespace: {{ .Namespace }} 

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.0.0"
+	Version = "1.0.1"
 )


### PR DESCRIPTION
### Prerequisites
OSD 4.2 cluster

The followign Pr is to verify the JIRA Update AMO to include new Grafana Operator [Intly-4255](https://issues.redhat.com/browse/INTLY-4255).

### Verification
1. install AMO from my branch using the following https://github.com/integr8ly/application-monitoring-operator#installation
2. Once everything is installed and running check the following:
- The image path version in the grafana operator yaml this should v3.0.1
- The image path version in the application monitoring operator yaml this should v1.0.1
- In the grafana serviceAccount there should be a test annotations that looks like the following `test: asdfgh`
3. Lastly is to ensure that the logs have no errors
