### PR TITLE
service and rule selectors removed

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -73,11 +73,9 @@ spec:
     matchExpressions:
       - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
   serviceMonitorSelector:
-    matchExpressions:
-      - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
+    any: true
   ruleSelector:
-    matchExpressions:
-      - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }
+    any: true
   ruleNamespaceSelector:
     matchExpressions:
       - { key: "monitoring-key", operator: In, values: [{{ .MonitoringKey }}] }


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/INTLY-3137?focusedCommentId=13820290&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13820290

Once this is verified and merged, another PR will be created for the `integreatly-operator` which incorporates the removal of the `monitoring-key` label from individual resources.

## Prerequisites

- Openshift 4.2 RHPDS cluster

## Verification

- Login in to your cluster using `oc login`
- Run the Operator locally as per the [instructions](https://github.com/integr8ly/application-monitoring-operator#running-locally-for-development)
- Once the operator is running, navigate to the Prometheus route in the `application-monitoring` namespace. The route should contain a single alert named - `DeadMansSwitch`
- Remove the `monitoring-key: middle` label from the above Prometheus rule:

  `oc label prometheusrules prometheus-application-monitoring-rules monitoring-key- -n application   -monitoring`

- Allow a minute or 2 to pass, then verify that the `DeadMansSwitch` alert still exists in Prometheus.
