### PR TITLE
Local setup fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ COMPILE_TARGET=./tmp/_output/bin/$(PROJECT)
 # You can delete this comment afterwards.
 PROMETHEUS_OPERATOR_VERSION=v0.34.0
 GRAFANA_OPERATOR_VERSION=v3.0.1
+LOCAL=local
 
 
 .PHONY: setup/dep
@@ -103,3 +104,7 @@ cluster/create/examples:
 .PHONY: cluster/install
 cluster/install:
 	./scripts/install.sh  ${PROMETHEUS_OPERATOR_VERSION} ${GRAFANA_OPERATOR_VERSION}
+
+.PHONY: cluster/install/local
+cluster/install/local:
+	./scripts/install.sh  ${PROMETHEUS_OPERATOR_VERSION} ${GRAFANA_OPERATOR_VERSION} ${LOCAL}

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You can run the Operator locally against a remote namespace. The name of the nam
 
 ```sh
 $ make setup/dep
+$ make cluster/install/local
 $ make code/run
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,5 +39,8 @@ until oc auth can-i create prometheus -n application-monitoring --as system:serv
     echo "Waiting for all CRDs and SA permissions to be applied before deploying operator..." && sleep 1
 done
 
-oc apply -f ./deploy/operator.yaml
+if [ -z "$3" ]; then
+   oc apply -f ./deploy/operator.yaml
+fi
+
 oc apply -f ./deploy/examples/ApplicationMonitoring.yaml


### PR DESCRIPTION
## Description

The current `README` instructions to run the Operator locally, and along with the corresponding files,
are outdated and required updating.

## Prerequisites

- Openshift 4.2 RHPDS cluster

## Verification

- Login in to your cluster using `oc login`
- Follow the `README` instructions to run the Operator locally
- Verify that the Operator successfully installs without error, and that the instructions are both clear and concise.
