### PR TITLE
added missing resources to applicaiton-monitoring-operator role

### DIFF
--- a/deploy/operator_roles/role.yaml
+++ b/deploy/operator_roles/role.yaml
@@ -50,8 +50,11 @@ rules:
   - integreatly.org
   resources:
   - grafanadatasources
+  - grafanadatasources/status
   - grafanadashboards
+  - grafanadashboards/status
   - grafanas
+  - grafanas/status
   - grafanas/finalizers
   - grafanadatasources/finalizers
   - grafanadashboards/finalizers


### PR DESCRIPTION
Added missing resources in application-monitoring-operator role for deploying the grafana operator

Was generating the following errors in the application-monitoring-operator pod logs as described in issue #109 

```
    "msg": "Error in InstallGrafanaOperator, \n    resourceName=grafana-operator-role : err=error creating resource: roles.rbac.authorization.k8s.io 
    \"grafana-operator-role\" is forbidden: attempt to grant extra privileges: \n    [
        {[*] [integreatly.org] [grafanadashboards/status] [] []} 
        {[*] [integreatly.org] [grafanadatasources/status] [] []} 
        {[*] [integreatly.org] [grafanas/status] [] []}] 
```

Signed-off-by: Byron.Collins <byron_collins@hotmail.com>
