### PR TITLE
fix image builds and pushing in travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ jobs:
         - make setup/travis code/check test/unit
     - stage: compile
       script:
-        - make setup/travis image/build TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
+        - make setup/travis image/build AMO_VERSION=$(git rev-parse --short ${TRAVIS_COMMIT})
     - stage: push
       script:
         - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
         - export TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
         - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io
-        - make setup/travis image/build/push TAG=$TAG
+        - make setup/travis image/build/push AMO_VERSION=$TAG
         - docker tag quay.io/integreatly/$OPERATOR_NAME:$TAG quay.io/integreatly/$OPERATOR_NAME:$BRANCH
         - docker push quay.io/integreatly/$OPERATOR_NAME:$BRANCH

--- a/Makefile
+++ b/Makefile
@@ -61,18 +61,18 @@ code/fix:
 
 .PHONY: image/build
 image/build: code/compile
-	@operator-sdk build ${REG}/${ORG}/${PROJECT}:v${AMO_VERSION}
+	@operator-sdk build ${REG}/${ORG}/${PROJECT}:${AMO_VERSION}
 
 .PHONY: image/push
 image/push:
-	docker push ${REG}/${ORG}/${PROJECT}:v${AMO_VERSION}
+	docker push ${REG}/${ORG}/${PROJECT}:${AMO_VERSION}
 
 .PHONY: image/build/push
 image/build/push: image/build image/push
 
 .PHONY: image/build/test
 image/build/test:
-	operator-sdk build --enable-tests ${REG}/${ORG}/${PROJECT}:v${AMO_VERSION}
+	operator-sdk build --enable-tests ${REG}/${ORG}/${PROJECT}:${AMO_VERSION}
 
 .PHONY: test/unit
 test/unit:


### PR DESCRIPTION
currenly travis is not building the correct image when performing
a release, this is causing releases of amo not to publish images.

verification:
- check the travis job on the pull-request of this commit
- ensure the correct image is being built in the compile stage