### PR TITLE
updated dockerfile to use ubi image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:3.8
-
-RUN apk upgrade --update --no-cache
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 USER nobody
 


### PR DESCRIPTION
The alpine image being used in the dockerfile was being replaced when built, meaning the apk upgrade command failed. The Dockerfile has been updated to fix this.

Verification:
- Clone this repo
- Build image from dockerfile
- verify build succeeds