### PR TITLE
Fix to remove the readiness probe in the operator yaml.

### DIFF
--- a/templates/grafana-operator.yaml
+++ b/templates/grafana-operator.yaml
@@ -27,14 +27,6 @@ spec:
           command:
           - "{{ .GrafanaOperatorName }}"
           imagePullPolicy: Always
-          readinessProbe:
-            exec:
-              command:
-                - stat
-                - /tmp/operator-sdk-ready
-            initialDelaySeconds: 4
-            periodSeconds: 10
-            failureThreshold: 1
           env:
             - name: TEMPLATE_PATH
               value: /usr/local/bin/templates


### PR DESCRIPTION
JIRA Link: https://issues.redhat.com/browse/INTLY-8046

The removal of readiness probe from the operator yaml was missed
in the previous PR. this cause the pod to not transition into
ready state.