### PR TITLE
remove subresources from crd

### DIFF
--- a/deploy/crds/applicationmonitoring.integreatly.org_applicationmonitorings_crd.yaml
+++ b/deploy/crds/applicationmonitoring.integreatly.org_applicationmonitorings_crd.yaml
@@ -10,8 +10,6 @@ spec:
     plural: applicationmonitorings
     singular: applicationmonitoring
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       description: ApplicationMonitoring is the Schema for the applicationmonitorings


### PR DESCRIPTION
Remove the subresources from the AMO CRD because we have not updated the controllers to use `.Status().Update()`. Without this change, the operator will get stuck because it can't update its phase.

The RHMI operator has addressed this in their copies of the CRDs: https://github.com/integr8ly/integreatly-operator/blob/master/manifests/integreatly-monitoring/1.2.1/applicationmonitoring.integreatly.org_applicationmonitorings_crd.yaml