### PR TITLE
Switch to quay.io/integreatly/prometheus-blackbox-exporter

### DIFF
--- a/pkg/controller/applicationmonitoring/templateHelper.go
+++ b/pkg/controller/applicationmonitoring/templateHelper.go
@@ -159,7 +159,7 @@ func newTemplateHelper(cr *applicationmonitoring.ApplicationMonitoring, extraPar
 		ImageTagPrometheusOperator:       "v0.40.0",
 		ImagePrometheus:                  "quay.io/openshift/origin-prometheus",
 		ImageTagPrometheus:               "4.9",
-		ImageBlackboxExporter:            "quay.io/prometheus/blackbox-exporter",
+		ImageBlackboxExporter:            "quay.io/integreatly/prometheus-blackbox-exporter",
 		ImageTagBlackboxExporter:         "v0.19.0",
 		PrometheusVersion:                "v2.19.0",
 		PriorityClassName:                cr.Spec.PriorityClassName,


### PR DESCRIPTION
This is done in order to be using image builds that are built in a secured environment with logging to Splunk instance.

For verification check that `v0.19.0` tag is available in the repo:
https://quay.io/repository/integreatly/prometheus-blackbox-exporter?tab=tags
Then install AMO from this branch and validate that metrics for the blackbox targets are being collected.
